### PR TITLE
Testing mosaic release 13.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "@mui/material": "5.8.7",
     "@mui/styles": "5.6.2",
     "@mui/x-date-pickers": "^5.0.0-beta.0",
-    "@simpleview/sv-mosaic": "12.0.0",
+    "@simpleview/sv-mosaic": "13.0.0-staging-696ca1",
     "date-fns": "2.29.1",
     "i18next": "21.8.11",
     "jsvalidator": "2.0.0",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,4 @@
 import "./styles.css";
-import { useEffect } from "react";
 import { Link, Routes, Route } from "react-router-dom";
 
 import Home from "./Home";
@@ -10,19 +9,10 @@ import FormPrefill from "./FormPrefill";
 import Drawers from "./Drawers";
 import Summary from "./Summary";
 import Dialog from "./Dialog";
-
-import { db } from "./db";
-
-import localStorageDB from "localstoragedb";
-const database = new localStorageDB("new_docs", localStorage);
+import useDb from "./useDb";
 
 export default function App() {
-  useEffect(() => {
-    if (database.isNew()) {
-      database.createTableWithData("data", db);
-      database.commit();
-    }
-  }, []);
+  useDb();
 
   return (
     <div className="App">

--- a/src/DataView.tsx
+++ b/src/DataView.tsx
@@ -1,8 +1,10 @@
 import { DataView as MosaicDataView } from "@simpleview/sv-mosaic";
-
 import useGrid from "./useGrid";
+import useDb from "./useDb";
 
 export default function DataView() {
+  useDb();
+
   const args = useGrid();
 
   return <MosaicDataView {...args} />;

--- a/src/Dialog.tsx
+++ b/src/Dialog.tsx
@@ -1,4 +1,4 @@
-import { Button, FormDialog as Dialog } from "@simpleview/sv-mosaic";
+import { Button, Dialog } from "@simpleview/sv-mosaic";
 import React from "react";
 
 export default function () {

--- a/src/db.ts
+++ b/src/db.ts
@@ -1,118 +1,118 @@
 export const db = [
   {
-    id: 0,
+    id: "0",
     foo: "Text 0",
     bar: "Example 0",
     date: "2022-04-29T14:35:13.613Z",
     boolean: true.toString()
   },
   {
-    id: 1,
+    id: "1",
     foo: "Text 1",
     bar: "Example 1",
     date: "2022-04-29T14:35:13.613Z",
     boolean: true.toString()
   },
   {
-    id: 2,
+    id: "2",
     foo: "Text 2",
     bar: "Example 2",
     date: "2022-03-29T09:11:15.315Z",
     boolean: true.toString()
   },
   {
-    id: 3,
+    id: "3",
     foo: "Text 3",
     bar: "Example 3",
     date: "2022-03-02T05:35:27.095Z",
     boolean: false.toString()
   },
   {
-    id: 4,
+    id: "4",
     foo: "Text 4",
     bar: "Example 4",
     date: "2022-01-22T04:10:29.631Z",
     boolean: true.toString()
   },
   {
-    id: 5,
+    id: "5",
     foo: "Text 5",
     bar: "Example 5",
     date: "2022-01-04T03:42:48.867Z",
     boolean: true.toString()
   },
   {
-    id: 6,
+    id: "6",
     foo: "Text 6",
     bar: "Example 6",
     date: "2022-01-12T18:29:02.131Z",
     boolean: false.toString()
   },
   {
-    id: 7,
+    id: "7",
     foo: "Text 7",
     bar: "Example 7",
     date: "2022-12-23T10:51:19.615Z",
     boolean: false.toString()
   },
   {
-    id: 8,
+    id: "8",
     foo: "Text 8",
     bar: "Example 8",
     date: "2022-02-10T22:26:56.246Z",
     boolean: true.toString()
   },
   {
-    id: 9,
+    id: "9",
     foo: "Text 9",
     bar: "Example 9",
     date: "2022-06-09T06:36:11.842Z",
     boolean: true.toString()
   },
   {
-    id: 10,
+    id: "10",
     foo: "Text 10",
     bar: "Example 10",
     date: "2022-11-05T09:26:08.745Z",
     boolean: false.toString()
   },
   {
-    id: 11,
+    id: "11",
     foo: "Text 11",
     bar: "Example 11",
     date: "2022-09-30T22:18:39.452Z",
     boolean: true.toString()
   },
   {
-    id: 12,
+    id: "12",
     foo: "Text 12",
     bar: "Example 12",
     date: "2022-01-15T05:22:04.668Z",
     boolean: true.toString()
   },
   {
-    id: 13,
+    id: "13",
     foo: "Text 13",
     bar: "Example 13",
     date: "2022-06-11T05:34:51.228Z",
     boolean: true.toString()
   },
   {
-    id: 14,
+    id: "14",
     foo: "Text 14",
     bar: "Example 14",
     date: "2022-07-06T12:23:05.326Z",
     boolean: false.toString()
   },
   {
-    id: 15,
+    id: "15",
     foo: "Text 15",
     bar: "Example 15",
     date: "2022-09-01T21:42:13.637Z",
     boolean: true.toString()
   },
   {
-    id: 16,
+    id: "16",
     foo: "Text 16",
     bar: "Example 16",
     date: "2022-06-11T05:34:51.228Z",

--- a/src/gridReducer.ts
+++ b/src/gridReducer.ts
@@ -339,7 +339,7 @@ const views: DataViewProps["savedView"][] = [
     state: {
       limit: 10,
       skip: 0,
-      activeColumns: ["id", "foo"],
+      activeColumns: ["id", "foo"]
     }
   },
   {
@@ -368,27 +368,22 @@ const views: DataViewProps["savedView"][] = [
 
 const savedView = views[2];
 
-const filters: DataViewProps["filters"] = [
+// omit onChange because they get added in useGrid hook
+const filters: Omit<DataViewProps["filters"], "onChange"> = [
   {
     name: "foo",
     label: "Foo",
-    //@ts-expect-error
-    component: DataViewFilterText,
-    type: "primary"
+    component: DataViewFilterText
   },
   {
     name: "date",
     label: "Date",
-    //@ts-expect-error
-    component: DataViewFilterDate,
-    type: "primary"
+    component: DataViewFilterDate
   },
   {
     name: "boolean",
     label: "Boolean",
-    //@ts-expect-error
     component: DataViewFilterSingleSelect,
-    type: "optional",
     args: {
       getSelected: getSingleSelectSelected,
       getOptions: getSingleSelectOptions
@@ -397,9 +392,7 @@ const filters: DataViewProps["filters"] = [
   {
     name: "bar",
     label: "Bar",
-    //@ts-expect-error
     component: DataViewFilterMultiselect,
-    type: "optional",
     args: {
       getSelected: getMultiSelectSelected,
       getOptions: getMultiSelectOptions
@@ -413,14 +406,15 @@ export const initialState = {
   data: [],
   count: 0,
   columns,
-  activeColumns: columns.map((c) => c.name),
+  _activeColumns: columns.map((c) => c.name),
+  activeColumns: ["wow"],
   sort: {
-    name: "id",
+    name: "foo",
     dir: "asc"
   },
   filter: {},
   filters,
-  activeFilters: [],
+  activeFilters: ["foo", "date"],
   buttons,
   primaryActions,
   views,

--- a/src/gridReducer.ts
+++ b/src/gridReducer.ts
@@ -406,8 +406,7 @@ export const initialState = {
   data: [],
   count: 0,
   columns,
-  _activeColumns: columns.map((c) => c.name),
-  activeColumns: ["wow"],
+  activeColumns: columns.map((c) => c.name),
   sort: {
     name: "foo",
     dir: "asc"

--- a/src/useBaseForm.ts
+++ b/src/useBaseForm.ts
@@ -41,7 +41,12 @@ export default function useBaseForm(): FormProps {
       label: "Coords",
       type: "mapCoordinates",
       inputSettings: {
-        apiKey: "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac"
+        apiKey: "AIzaSyArV4f-KFF86Zn9VWAu9wS4hHlG1TXxqac",
+        address: {},
+        mapPosition: {
+          lat: 0,
+          lng: 0
+        }
       }
     },
     {

--- a/src/useBaseForm.ts
+++ b/src/useBaseForm.ts
@@ -133,6 +133,28 @@ export default function useBaseForm(): FormProps {
           }
         ]
       }
+    },
+    {
+      name: "advanced-selection",
+      label: "Advanced Selection",
+      type: "advancedSelection",
+      inputSettings: {
+        selectLimit: 2,
+        createNewOption: (value) => ({
+          label: `Option ${value}`,
+          value: `option-${value}`
+        }),
+        options: [
+          {
+            label: "Option 1",
+            value: "option-1"
+          },
+          {
+            label: "Option 2",
+            value: "option-2"
+          }
+        ]
+      }
     }
   ];
 

--- a/src/useDb.tsx
+++ b/src/useDb.tsx
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+import { db } from "./db";
+import localStorageDB from "localstoragedb";
+const database = new localStorageDB("new_docs", localStorage);
+
+export const useDb = () => {
+  useEffect(() => {
+    if (!database.tableExists("data")) {
+      database.createTableWithData("data", db);
+      database.commit();
+    }
+  }, []);
+
+  return db;
+};
+
+export default useDb;

--- a/src/useGrid.tsx
+++ b/src/useGrid.tsx
@@ -58,7 +58,6 @@ export default function useGrid(): DataViewProps {
       return {
         name: val.name,
         label: val.label,
-        type: val.type,
         args: val.args,
         component: val.component,
         onChange: (value) => {


### PR DESCRIPTION
> This PR shouldn't be merged in until mosaic has live-released 13, and we have updated the sandbox to use that live release.
* Functionality all seems to be working
* The only concerns I have are related to console logs (and so therefore low priority)
  * Dataview prints out many `react-beautiful-dnd` warnings, even though the sandbox isn't enabling drag and drop. They also re-print every time I change filters, such as by clicking "Clear Filters"
  * Specific warning:
 ```
 ### react-beautiful-dnd
A setup problem was encountered.
> Invariant failed: Draggable requires a [string] draggableId.
Provided: [type: number] (value: 4)
 ```
  * The Changelog says it shows an error for propping down `activeColumns` that don't exist, but I did not see this. The error does appear for `activeFilters` though.
  * I saw this warning when using the advanced selection component:
```The component styled.div with the id of "sc-cKajLJ" has been created dynamically.
You may see this warning because you've called styled inside another component.
To resolve this only create new StyledComponents outside of any render method and function component. 
    in LoadMoreButton (created by Col)
    in Col (created by Row)
    in Row (created by Section)
    in Section (created by Section)
    in Section (created by FormLayout)
    in FormLayout (created by FormLayout)
    in FormLayout (created by Form)
    in Form (created by AdvancedSelectionDrawer)
    in AdvancedSelectionDrawer (created by FormFieldAdvancedSelection)
    in FormFieldAdvancedSelection (created by Col)
    in Col (created by Row)
    in Row (created by Section)
    in Section (created by Section)
    in Section (created by FormLayout)
    in FormLayout (created by FormLayout)
    in FormLayout (created by Form)
    in Form (created by Form)
    in Form (created by App)
    in App 
```
* The storybook docs also still refer to the `types` property for the dataview filters